### PR TITLE
Fixed TypeError in Python 3.x

### DIFF
--- a/bin/latencies.py
+++ b/bin/latencies.py
@@ -96,7 +96,7 @@ def _render_block(number, color=None, caption=None):
         color_off = ''
 
     # creating block itself
-    for _ in range(number / size_x):
+    for _ in range(number // size_x):
         spaces = " "*(lane_size - size_x*2)
         answer += [BLOCK*size_x + spaces]
 


### PR DESCRIPTION
Couldn't run with Python 3 due to a TypeError being raised due to a float being provided to the range function instead of int.

Tested in Python 2.7.15, 3.6.6, 3.7.0.

```
  File "late.nz/bin/latencies.py", line 100, in _render_block
    for _ in range(number / size_x):
```